### PR TITLE
Feature/#136/milestone create update network

### DIFF
--- a/backend/routes/api/milestone-api.js
+++ b/backend/routes/api/milestone-api.js
@@ -3,7 +3,7 @@ const controller = require('../../controllers/milestone-controller');
 
 router.post('/', controller.addMilestone);
 router.get('/all', controller.getMilestones);
-router.patch('/', controller.updateMilestone);
+router.put('/', controller.updateMilestone);
 router.delete('/', controller.deleteMilestone);
 
 module.exports = router;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -969,6 +969,16 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/preset-env": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.1.tgz",
@@ -1898,6 +1908,43 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2724,6 +2771,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
     "core-js-compat": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
+    "@babel/polyfill": "^7.11.5",
     "babel-loader": "^8.1.0",
     "babel-plugin-styled-components": "^1.11.1",
     "clean-webpack-plugin": "^3.0.0",
@@ -33,7 +34,8 @@
     "style-loader": "^2.0.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0",
+    "babel-polyfill": "^6.26.0"
   },
   "dependencies": {
     "@primer/octicons-react": "^11.0.0",

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -29,8 +29,7 @@ const App = ({ milestoneService }) => {
         />
         <Route
           path="/milestone/edit"
-          milestoneService={milestoneService}
-          component={EditMilestone}
+          render={() => <EditMilestone milestoneService={milestoneService} />}
         />
         <Route path="/labels" component={Label} />
         <Route path="/issue/create" component={IssueCreation} />

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -12,14 +12,27 @@ import {
   Issue,
 } from './pages';
 
-const App = () => {
+const App = ({ milestoneService }) => {
   return (
     <BrowserRouter>
       <Switch>
         <Route exact path="/" component={Login} />
-        <Route exact path="/milestones" component={Milestone} />
-        <Route path="/milestone/new" component={CreateMilestone} />
-        <Route path="/milestone/edit" component={EditMilestone} />
+        <Route
+          exact
+          path="/milestones"
+          milestoneService={milestoneService}
+          component={Milestone}
+        />
+        <Route
+          path="/milestone/new"
+          milestoneService={milestoneService}
+          component={CreateMilestone}
+        />
+        <Route
+          path="/milestone/edit"
+          milestoneService={milestoneService}
+          component={EditMilestone}
+        />
         <Route path="/labels" component={Label} />
         <Route path="/issue/create" component={IssueCreation} />
         <Route path="/issues" component={Issue} />

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -25,8 +25,7 @@ const App = ({ milestoneService }) => {
         />
         <Route
           path="/milestone/new"
-          milestoneService={milestoneService}
-          component={CreateMilestone}
+          render={() => <CreateMilestone milestoneService={milestoneService} />}
         />
         <Route
           path="/milestone/edit"

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import './app.css';
 
 import { BrowserRouter, Route, Switch } from 'react-router-dom';

--- a/frontend/src/components/Common/GreenButton.js
+++ b/frontend/src/components/Common/GreenButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export default function CreateButton(props) {
-  return <Button>{props.content}</Button>;
+export default function CreateButton({ onClick, content }) {
+  return <Button onClick={onClick}>{content}</Button>;
 }
 
 const Button = styled.button`

--- a/frontend/src/components/CreateMilestone/buttons.js
+++ b/frontend/src/components/CreateMilestone/buttons.js
@@ -4,7 +4,13 @@ import CreateButton from '../Common/GreenButton';
 
 export default function buttons({ milestoneService }) {
   const createMilestone = () => {
-    console.log('create milestone');
+    milestoneService.createMilestone('http://localhost:3000/api/milestone', {
+      issue_id: 3,
+      milestone_name: 'postfetch test',
+      milestone_description: 'postfetch !!',
+      end_date: '2020-11-08',
+      status: 'open',
+    });
   };
 
   return (

--- a/frontend/src/components/CreateMilestone/buttons.js
+++ b/frontend/src/components/CreateMilestone/buttons.js
@@ -1,9 +1,11 @@
 import React, { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import CreateButton from '../Common/GreenButton';
 
 export default function buttons({ Context, milestoneService }) {
   const milestoneInfo = useContext(Context);
+  const history = useHistory();
 
   const createMilestone = () => {
     milestoneService.createMilestone('http://localhost:3000/api/milestone', {
@@ -13,6 +15,7 @@ export default function buttons({ Context, milestoneService }) {
       end_date: milestoneInfo.dueDate,
       status: 'open',
     });
+    history.push('/milestones');
   };
 
   return (

--- a/frontend/src/components/CreateMilestone/buttons.js
+++ b/frontend/src/components/CreateMilestone/buttons.js
@@ -2,11 +2,15 @@ import React from 'react';
 import styled from 'styled-components';
 import CreateButton from '../Common/GreenButton';
 
-export default function buttons(props) {
+export default function buttons({ milestoneService }) {
+  const createMilestone = () => {
+    console.log('create milestone');
+  };
+
   return (
     <Wrapper>
       <ButtonWrapper>
-        <CreateButton content="Create milestone" />
+        <CreateButton onClick={createMilestone} content="Create milestone" />
       </ButtonWrapper>
     </Wrapper>
   );

--- a/frontend/src/components/CreateMilestone/buttons.js
+++ b/frontend/src/components/CreateMilestone/buttons.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import CreateButton from '../Common/GreenButton';
 
-export default function buttons({ milestoneService }) {
+export default function buttons({ Context, milestoneService }) {
+  const milestoneInfo = useContext(Context);
+
   const createMilestone = () => {
     milestoneService.createMilestone('http://localhost:3000/api/milestone', {
-      issue_id: 3,
-      milestone_name: 'postfetch test',
-      milestone_description: 'postfetch !!',
-      end_date: '2020-11-08',
+      issue_id: 0,
+      milestone_name: milestoneInfo.title,
+      milestone_description: milestoneInfo.desc,
+      end_date: milestoneInfo.dueDate,
       status: 'open',
     });
   };

--- a/frontend/src/components/CreateMilestone/inputDescription.js
+++ b/frontend/src/components/CreateMilestone/inputDescription.js
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-export default function InputDescription({ SetDescContext }) {
+export default function InputDescription({ SetDescContext, milestoneInfo }) {
   const setDesc = useContext(SetDescContext);
   const onChange = e => {
-    setDesc(e.target.value);
+    setDesc({ ...milestoneInfo, desc: e.target.value });
   };
   return (
     <Wrapper>

--- a/frontend/src/components/CreateMilestone/inputDescription.js
+++ b/frontend/src/components/CreateMilestone/inputDescription.js
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
-export default function InputDescription(props) {
+export default function InputDescription({ SetDescContext }) {
+  const setDesc = useContext(SetDescContext);
+  const onChange = e => {
+    setDesc(e.target.value);
+  };
   return (
     <Wrapper>
       <Description>Description</Description>
-      <DescriptionInput />
+      <DescriptionInput onChange={onChange} />
     </Wrapper>
   );
 }

--- a/frontend/src/components/CreateMilestone/inputDueDate.js
+++ b/frontend/src/components/CreateMilestone/inputDueDate.js
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-export default function InputDueDate({ SetDueDateContext }) {
+export default function InputDueDate({ SetDueDateContext, milestoneInfo }) {
   const setDueDate = useContext(SetDueDateContext);
   const onChange = e => {
-    setDueDate(e.target.value);
+    setDueDate({ ...milestoneInfo, dueDate: e.target.value });
   };
 
   return (

--- a/frontend/src/components/CreateMilestone/inputDueDate.js
+++ b/frontend/src/components/CreateMilestone/inputDueDate.js
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
-export default function InputDueDate(props) {
+export default function InputDueDate({ SetDueDateContext }) {
+  const setDueDate = useContext(SetDueDateContext);
+  const onChange = e => {
+    setDueDate(e.target.value);
+  };
+
   return (
     <Wrapper>
       <DueDate>Due Date(optional)</DueDate>
-      <DueDateInput type="date" />
+      <DueDateInput type="date" onChange={onChange} />
     </Wrapper>
   );
 }

--- a/frontend/src/components/CreateMilestone/inputForm.js
+++ b/frontend/src/components/CreateMilestone/inputForm.js
@@ -12,7 +12,6 @@ const SetDescContext = createContext(() => {});
 const MilestoneContext = createContext('');
 
 export default function InputForm({ milestoneService, type }) {
-  console.log(type);
   const [title, setTitle] = useState('');
   const [dueDate, setDueDate] = useState('');
   const [desc, setDesc] = useState('');
@@ -32,7 +31,12 @@ export default function InputForm({ milestoneService, type }) {
       </Wrapper>
 
       {type === 'edit' ? (
-        <EditButtons />
+        <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+          <EditButtons
+            Context={MilestoneContext}
+            milestoneService={milestoneService}
+          />
+        </MilestoneContext.Provider>
       ) : (
         <MilestoneContext.Provider value={{ title, dueDate, desc }}>
           <Buttons

--- a/frontend/src/components/CreateMilestone/inputForm.js
+++ b/frontend/src/components/CreateMilestone/inputForm.js
@@ -30,21 +30,19 @@ export default function InputForm({ milestoneService, type }) {
         </SetDescContext.Provider>
       </Wrapper>
 
-      {type === 'edit' ? (
-        <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+      <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+        {type === 'edit' ? (
           <EditButtons
             Context={MilestoneContext}
             milestoneService={milestoneService}
           />
-        </MilestoneContext.Provider>
-      ) : (
-        <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+        ) : (
           <Buttons
             Context={MilestoneContext}
             milestoneService={milestoneService}
           />
-        </MilestoneContext.Provider>
-      )}
+        )}
+      </MilestoneContext.Provider>
     </>
   );
 }

--- a/frontend/src/components/CreateMilestone/inputForm.js
+++ b/frontend/src/components/CreateMilestone/inputForm.js
@@ -4,13 +4,15 @@ import InputTitle from './inputTitle';
 import InputDueDate from './inputDueDate';
 import InputDescription from './inputDescription';
 import Buttons from './buttons';
+import EditButtons from '../EditMilestone/buttons';
 
 const SetTitleContext = createContext(() => {});
 const SetDueDateContext = createContext(() => {});
 const SetDescContext = createContext(() => {});
 const MilestoneContext = createContext('');
 
-export default function InputForm({ milestoneService }) {
+export default function InputForm({ milestoneService, type }) {
+  console.log(type);
   const [title, setTitle] = useState('');
   const [dueDate, setDueDate] = useState('');
   const [desc, setDesc] = useState('');
@@ -29,12 +31,16 @@ export default function InputForm({ milestoneService }) {
         </SetDescContext.Provider>
       </Wrapper>
 
-      <MilestoneContext.Provider value={{ title, dueDate, desc }}>
-        <Buttons
-          Context={MilestoneContext}
-          milestoneService={milestoneService}
-        />
-      </MilestoneContext.Provider>
+      {type === 'edit' ? (
+        <EditButtons />
+      ) : (
+        <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+          <Buttons
+            Context={MilestoneContext}
+            milestoneService={milestoneService}
+          />
+        </MilestoneContext.Provider>
+      )}
     </>
   );
 }

--- a/frontend/src/components/CreateMilestone/inputForm.js
+++ b/frontend/src/components/CreateMilestone/inputForm.js
@@ -6,31 +6,36 @@ import InputDescription from './inputDescription';
 import Buttons from './buttons';
 import EditButtons from '../EditMilestone/buttons';
 
-const SetTitleContext = createContext(() => {});
-const SetDueDateContext = createContext(() => {});
-const SetDescContext = createContext(() => {});
+const SetMilestoneContext = createContext(() => {});
 const MilestoneContext = createContext('');
 
 export default function InputForm({ milestoneService, type }) {
-  const [title, setTitle] = useState('');
-  const [dueDate, setDueDate] = useState('');
-  const [desc, setDesc] = useState('');
+  const [milestoneInfo, setMilestoneInfo] = useState({
+    title: '',
+    dueDate: '',
+    desc: '',
+  });
 
   return (
     <>
       <Wrapper>
-        <SetTitleContext.Provider value={setTitle}>
-          <InputTitle SetTitleContext={SetTitleContext} />
-        </SetTitleContext.Provider>
-        <SetDueDateContext.Provider value={setDueDate}>
-          <InputDueDate SetDueDateContext={SetDueDateContext} />
-        </SetDueDateContext.Provider>
-        <SetDescContext.Provider value={setDesc}>
-          <InputDescription SetDescContext={SetDescContext} />
-        </SetDescContext.Provider>
+        <SetMilestoneContext.Provider value={setMilestoneInfo}>
+          <InputTitle
+            SetTitleContext={SetMilestoneContext}
+            milestoneInfo={milestoneInfo}
+          />
+          <InputDueDate
+            SetDueDateContext={SetMilestoneContext}
+            milestoneInfo={milestoneInfo}
+          />
+          <InputDescription
+            SetDescContext={SetMilestoneContext}
+            milestoneInfo={milestoneInfo}
+          />
+        </SetMilestoneContext.Provider>
       </Wrapper>
 
-      <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+      <MilestoneContext.Provider value={milestoneInfo}>
         {type === 'edit' ? (
           <EditButtons
             Context={MilestoneContext}

--- a/frontend/src/components/CreateMilestone/inputForm.js
+++ b/frontend/src/components/CreateMilestone/inputForm.js
@@ -1,17 +1,40 @@
-import React from 'react';
+import React, { createContext, useState } from 'react';
 import styled from 'styled-components';
 import InputTitle from './inputTitle';
 import InputDueDate from './inputDueDate';
 import InputDescription from './inputDescription';
+import Buttons from './buttons';
 
-export default function InputForm(props) {
+const SetTitleContext = createContext(() => {});
+const SetDueDateContext = createContext(() => {});
+const SetDescContext = createContext(() => {});
+const MilestoneContext = createContext('');
+
+export default function InputForm({ milestoneService }) {
+  const [title, setTitle] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [desc, setDesc] = useState('');
+
   return (
     <>
       <Wrapper>
-        <InputTitle />
-        <InputDueDate />
-        <InputDescription />
+        <SetTitleContext.Provider value={setTitle}>
+          <InputTitle SetTitleContext={SetTitleContext} />
+        </SetTitleContext.Provider>
+        <SetDueDateContext.Provider value={setDueDate}>
+          <InputDueDate SetDueDateContext={SetDueDateContext} />
+        </SetDueDateContext.Provider>
+        <SetDescContext.Provider value={setDesc}>
+          <InputDescription SetDescContext={SetDescContext} />
+        </SetDescContext.Provider>
       </Wrapper>
+
+      <MilestoneContext.Provider value={{ title, dueDate, desc }}>
+        <Buttons
+          Context={MilestoneContext}
+          milestoneService={milestoneService}
+        />
+      </MilestoneContext.Provider>
     </>
   );
 }

--- a/frontend/src/components/CreateMilestone/inputTitle.js
+++ b/frontend/src/components/CreateMilestone/inputTitle.js
@@ -1,11 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 
-export default function InputTitle(props) {
+export default function InputTitle({ SetTitleContext }) {
+  const setTitle = useContext(SetTitleContext);
+
+  const onChange = e => {
+    setTitle(e.target.value);
+  };
+
   return (
     <Wrapper>
       <Title>Title</Title>
-      <TitleInput type="text" placeholder="Title" />
+      <TitleInput type="text" placeholder="Title" onChange={onChange} />
     </Wrapper>
   );
 }

--- a/frontend/src/components/CreateMilestone/inputTitle.js
+++ b/frontend/src/components/CreateMilestone/inputTitle.js
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 
-export default function InputTitle({ SetTitleContext }) {
+export default function InputTitle({ SetTitleContext, milestoneInfo }) {
   const setTitle = useContext(SetTitleContext);
 
   const onChange = e => {
-    setTitle(e.target.value);
+    setTitle({ ...milestoneInfo, title: e.target.value });
   };
 
   return (

--- a/frontend/src/components/EditMilestone/buttons.js
+++ b/frontend/src/components/EditMilestone/buttons.js
@@ -3,13 +3,23 @@ import styled from 'styled-components';
 import NormalButton from '../Common/NormalButton';
 import SaveButton from '../Common/GreenButton';
 
-export default function Buttons(props) {
+export default function Buttons({ milestoneService }) {
+  const updateMilestone = () => {
+    milestoneService.updateMilestone('http://localhost:3000/api/milestone', {
+      id: 7,
+      issue_id: 3,
+      milestone_name: 'updatefetch',
+      milestone_description: 'updatefetch!!!!!',
+      end_date: '2020-11-08',
+      status: 'closed',
+    });
+  };
   return (
     <Wrapper>
       <ButtonSet>
         <NormalButton content="Cancel" />
         <NormalButton content="Close milestone" />
-        <SaveButton content="Save Change" />
+        <SaveButton onClick={updateMilestone} content="Save Change" />
       </ButtonSet>
     </Wrapper>
   );

--- a/frontend/src/components/EditMilestone/buttons.js
+++ b/frontend/src/components/EditMilestone/buttons.js
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import NormalButton from '../Common/NormalButton';
 import SaveButton from '../Common/GreenButton';
 
 export default function Buttons({ Context, milestoneService }) {
   const milestoneInfo = useContext(Context);
+  const history = useHistory();
 
   const updateMilestone = () => {
     milestoneService.updateMilestone('http://localhost:3000/api/milestone', {
@@ -15,6 +17,7 @@ export default function Buttons({ Context, milestoneService }) {
       end_date: milestoneInfo.dueDate,
       status: 'open',
     });
+    history.push('/milestones');
   };
   return (
     <Wrapper>
@@ -36,7 +39,7 @@ const Wrapper = styled.div`
 const ButtonSet = styled.div`
   position: absolute;
   right: 0;
-  width: 25%;
+  gap: 1em;
   display: flex;
   justify-content: space-around;
 `;

--- a/frontend/src/components/EditMilestone/buttons.js
+++ b/frontend/src/components/EditMilestone/buttons.js
@@ -6,6 +6,7 @@ import SaveButton from '../Common/GreenButton';
 
 export default function Buttons({ Context, milestoneService }) {
   const milestoneInfo = useContext(Context);
+
   const history = useHistory();
 
   const updateMilestone = () => {

--- a/frontend/src/components/EditMilestone/buttons.js
+++ b/frontend/src/components/EditMilestone/buttons.js
@@ -1,17 +1,19 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import NormalButton from '../Common/NormalButton';
 import SaveButton from '../Common/GreenButton';
 
-export default function Buttons({ milestoneService }) {
+export default function Buttons({ Context, milestoneService }) {
+  const milestoneInfo = useContext(Context);
+
   const updateMilestone = () => {
     milestoneService.updateMilestone('http://localhost:3000/api/milestone', {
-      id: 7,
-      issue_id: 3,
-      milestone_name: 'updatefetch',
-      milestone_description: 'updatefetch!!!!!',
-      end_date: '2020-11-08',
-      status: 'closed',
+      id: 13,
+      issue_id: 0,
+      milestone_name: milestoneInfo.title,
+      milestone_description: milestoneInfo.desc,
+      end_date: milestoneInfo.dueDate,
+      status: 'open',
     });
   };
   return (

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,7 +5,7 @@ import App from './app';
 import MilestoneService from './service/milestone';
 
 const milestoneService = new MilestoneService();
-console.log(milestoneService);
+
 ReactDOM.render(
   <App milestoneService={milestoneService} />,
   document.getElementById('root'),

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,5 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import App from './app';
+import MilestoneService from './service/milestone';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const milestoneService = new MilestoneService();
+
+ReactDOM.render(
+  <App milestoneService={milestoneService} />,
+  document.getElementById('root'),
+);

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,7 +5,7 @@ import App from './app';
 import MilestoneService from './service/milestone';
 
 const milestoneService = new MilestoneService();
-
+console.log(milestoneService);
 ReactDOM.render(
   <App milestoneService={milestoneService} />,
   document.getElementById('root'),

--- a/frontend/src/pages/CreateMilestone/createMilestone.js
+++ b/frontend/src/pages/CreateMilestone/createMilestone.js
@@ -4,16 +4,13 @@ import Header from '../../components/Common/Header';
 import Explanation from '../../components/CreateMilestone/explanation';
 import InputForm from '../../components/CreateMilestone/inputForm';
 import Footer from '../../components/Common/Footer';
-import Buttons from '../../components/CreateMilestone/buttons';
 
 const CreateMilestone = ({ milestoneService }) => {
-  console.log(milestoneService);
   return (
     <Wrapper>
       <Header />
       <Explanation />
-      <InputForm />
-      <Buttons milestoneService={milestoneService} />
+      <InputForm milestoneService={milestoneService} />
       <Footer />
     </Wrapper>
   );

--- a/frontend/src/pages/CreateMilestone/createMilestone.js
+++ b/frontend/src/pages/CreateMilestone/createMilestone.js
@@ -7,6 +7,7 @@ import Footer from '../../components/Common/Footer';
 import Buttons from '../../components/CreateMilestone/buttons';
 
 const CreateMilestone = ({ milestoneService }) => {
+  console.log(milestoneService);
   return (
     <Wrapper>
       <Header />

--- a/frontend/src/pages/CreateMilestone/createMilestone.js
+++ b/frontend/src/pages/CreateMilestone/createMilestone.js
@@ -6,13 +6,13 @@ import InputForm from '../../components/CreateMilestone/inputForm';
 import Footer from '../../components/Common/Footer';
 import Buttons from '../../components/CreateMilestone/buttons';
 
-const CreateMilestone = props => {
+const CreateMilestone = ({ milestoneService }) => {
   return (
     <Wrapper>
       <Header />
       <Explanation />
       <InputForm />
-      <Buttons />
+      <Buttons milestoneService={milestoneService} />
       <Footer />
     </Wrapper>
   );

--- a/frontend/src/pages/EditMilestone/editMilestone.js
+++ b/frontend/src/pages/EditMilestone/editMilestone.js
@@ -10,7 +10,7 @@ const EditMilestone = ({ milestoneService }) => {
     <>
       <Header />
       <NavButton />
-      <InputForm type="edit" />
+      <InputForm milestoneService={milestoneService} type="edit" />
       <Footer />
     </>
   );

--- a/frontend/src/pages/EditMilestone/editMilestone.js
+++ b/frontend/src/pages/EditMilestone/editMilestone.js
@@ -5,13 +5,13 @@ import InputForm from '../../components/CreateMilestone/inputForm';
 import Buttons from '../../components/EditMilestone/buttons';
 import Footer from '../../components/Common/Footer';
 
-const EditMilestone = props => {
+const EditMilestone = ({ milestoneService }) => {
   return (
     <>
       <Header />
       <NavButton />
       <InputForm />
-      <Buttons />
+      <Buttons milestoneService={milestoneService} />
       <Footer />
     </>
   );

--- a/frontend/src/pages/EditMilestone/editMilestone.js
+++ b/frontend/src/pages/EditMilestone/editMilestone.js
@@ -10,8 +10,7 @@ const EditMilestone = ({ milestoneService }) => {
     <>
       <Header />
       <NavButton />
-      <InputForm />
-      <Buttons milestoneService={milestoneService} />
+      <InputForm type="edit" />
       <Footer />
     </>
   );

--- a/frontend/src/service/fetch.js
+++ b/frontend/src/service/fetch.js
@@ -1,0 +1,46 @@
+export const getFetch = async query => {
+  const response = await fetch(`${query}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response;
+};
+
+export const postFetch = async (query, body) => {
+  const response = await fetch(`${query}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  return response;
+};
+
+export const updateFetch = async (query, body) => {
+  const response = await fetch(`${query}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  return response;
+};
+
+export const deleteFetch = async (query, body) => {
+  const response = await fetch(`${query}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  return response;
+};

--- a/frontend/src/service/milestone.js
+++ b/frontend/src/service/milestone.js
@@ -1,0 +1,13 @@
+import { postFetch, updateFetch } from './fetch';
+
+export default class MilestoneService {
+  constructor() {}
+
+  async createMilestone() {
+    const res = await postFetch();
+  }
+
+  async updateMilestone() {
+    const res = await updateFetch();
+  }
+}

--- a/frontend/src/service/milestone.js
+++ b/frontend/src/service/milestone.js
@@ -3,11 +3,11 @@ import { postFetch, updateFetch } from './fetch';
 export default class MilestoneService {
   constructor() {}
 
-  async createMilestone() {
-    const res = await postFetch();
+  async createMilestone(url, data) {
+    const res = await postFetch(url, data);
   }
 
-  async updateMilestone() {
-    const res = await updateFetch();
+  async updateMilestone(url, data) {
+    const res = await updateFetch(url, data);
   }
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-  entry: './src/index.js',
+  entry: ['babel-polyfill', './src/index.js'],
   output: {
     publicPath: '/',
     filename: 'bundle.[hash].js',


### PR DESCRIPTION
- [x] milestone API중 create와 update를 front와 연동

- [x] fetch를 위한 service layer 생성 
- async await사용을 위한 babel 설정
- fetch 메소드들 추상화
- 네트워크 통신 로직이 컴포넌트에 들어갈 경우 컴포넌트 테스트에서 불필요한 통신이 계속 이루어짐
- 외부에서 주입하는 식으로 하여, 테스트 시에는 mock 데이터와 통신하도록 한다.

- [x] contextAPI를 사용하여 컴포넌트간 데이터 관리

- [x] create, update 완료 후 라우팅